### PR TITLE
Stop installing a global __WARN__ handler at BEGIN time

### DIFF
--- a/lib/HTML/HTML5/Parser/Charset/DecodeHandle.pm
+++ b/lib/HTML/HTML5/Parser/Charset/DecodeHandle.pm
@@ -703,11 +703,13 @@ sub read ($$$;$) {
         $self->{bom_checked} = 1;
       }
       my $string = do {
-			BEGIN { $SIG{__WARN__} = sub { warn $_[0] unless $_[0] =~ /^Code point/ } }
-			Encode::decode ($self->{perl_encoding_name},
-                         $self->{byte_buffer},
-                         Encode::FB_QUIET ());
-		};
+        local $SIG{__WARN__} = sub { warn $_[0] unless $_[0] =~ /^Code point/ };
+        Encode::decode (
+          $self->{perl_encoding_name},
+          $self->{byte_buffer},
+          Encode::FB_QUIET(),
+        );
+      };
       if (length $string) {
         $self->{char_buffer} = \$string;
         $self->{char_buffer_pos} = 0;


### PR DESCRIPTION
Installing a global **WARN** handler when the package is loaded causes
extremely surprising action at a distance, particularly as no attempt is
made to call the previous **WARN** handler, if it existed.

Limit the scope of the warn handler to the single block which might
cause the warnings.
