### PR TITLE
[RT 96399] Better handling of utf-8 encoded html files

### DIFF
--- a/lib/HTML/HTML5/Parser.pm
+++ b/lib/HTML/HTML5/Parser.pm
@@ -13,6 +13,7 @@ use HTML::HTML5::Parser::Error;
 use HTML::HTML5::Parser::TagSoupParser;
 use Scalar::Util qw(blessed);
 use URI::file;
+use Encode qw(encode_utf8);
 use XML::LibXML;
 
 BEGIN {
@@ -102,6 +103,11 @@ sub parse_string
 	{
         # XXX AGAIN DO THIS TO STOP ENORMOUS MEMORY LEAKS
         my ($errh, $errors) = @{$self}{qw(error_handler errors)};
+        
+        if (utf8::is_utf8($text)) {
+			$text	= encode_utf8($text);
+		}
+		
 		$self->{parser}->parse_byte_string(
             $opts->{'encoding'}, $text, $dom,
             sub {

--- a/t/data/rt-96399-1.html
+++ b/t/data/rt-96399-1.html
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>title</title>
+  </head>
+  <body>
+    <p>↓</p>
+  </body>
+</html>

--- a/t/data/rt-96399-2.html
+++ b/t/data/rt-96399-2.html
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>title</title>
+  </head>
+  <body>
+    <p>é</p>
+  </body>
+</html>

--- a/t/rt-96399.t
+++ b/t/rt-96399.t
@@ -1,0 +1,21 @@
+use Test::More tests => 2;
+use HTML::HTML5::Parser;
+use Encode qw(decode_utf8);
+use Devel::Peek;
+
+subtest 'U+2193 DOWNWARDS ARROW' => sub {
+	my $filename	= 't/data/rt-96399-1.html';
+	my $parser = HTML::HTML5::Parser->new;
+	my $doc	= $parser->parse_file($filename);
+	is($parser->charset($doc), 'utf-8', 'recognized encoding as utf-8');
+	like(decode_utf8($doc->toString()), qr/\x{2193}/, 'encoding properly round-trips U+2193 DOWNWARDS ARROW');
+};
+
+subtest 'U+00E9 LATIN SMALL LETTER E WITH ACUTE' => sub {
+	my $filename	= 't/data/rt-96399-2.html';
+	my $parser = HTML::HTML5::Parser->new;
+	my $doc	= $parser->parse_file($filename);
+	is($parser->charset($doc), 'utf-8', 'recognized encoding as utf-8');
+	like(decode_utf8($doc->toString()), qr/\x{00E9}/, 'encoding properly round-trips U+00E9 DOWNWARDS ARROW');
+};
+

--- a/t/rt-96399.t
+++ b/t/rt-96399.t
@@ -19,3 +19,29 @@ subtest 'U+00E9 LATIN SMALL LETTER E WITH ACUTE' => sub {
 	like(decode_utf8($doc->toString()), qr/\x{00E9}/, 'encoding properly round-trips U+00E9 DOWNWARDS ARROW');
 };
 
+=head1 PURPOSE
+
+Test handling of utf-8 encoded file data
+
+=head1 SEE ALSO
+
+=over 4
+
+=item * L<https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=750946>
+
+=item * L<https://rt.cpan.org/Public/Bug/Display.html?id=96399>
+
+=back
+
+=head1 AUTHOR
+
+Gregory Todd Williams, E<lt>gwilliams@cpan.orgE<gt>
+
+=head1 COPYRIGHT AND LICENCE
+
+Copyright (C) 2017 by Gregory Todd Williams
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+
+=cut


### PR DESCRIPTION
I believe this fixes the bug reported in [debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=750946) and forwarded on to [RT](https://rt.cpan.org/Public/Bug/Display.html?id=96399).